### PR TITLE
Add Memory tab and UI polish for Book Mind

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -184,7 +184,7 @@ html.dark {
     --foreground: 0 0% 98%;
     --card: 0 0% 3.9%;
     --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
+    --popover: 0 0% 18%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
     --primary-foreground: 0 0% 9%;

--- a/app/make-ebook/components/EditorCanvas.tsx
+++ b/app/make-ebook/components/EditorCanvas.tsx
@@ -175,19 +175,19 @@ export default function EditorCanvas({
 
         {/* Word stats footer */}
         <div className="flex-shrink-0 flex items-center justify-between px-6 py-2 border-t border-gray-100 dark:border-gray-800/50">
-          <div className="flex items-center gap-4 text-xs text-gray-400 dark:text-gray-500">
+          <div className="flex items-center gap-4 text-xs text-gray-400 dark:text-gray-400">
             <span className="flex items-center gap-1.5">
-              <span className="text-gray-300 dark:text-gray-600">Chapter:</span>
+              <span className="text-gray-300 dark:text-gray-500">Chapter:</span>
               <span className="tabular-nums">{chapterWordCount.toLocaleString()} words</span>
             </span>
-            <span className="text-gray-300 dark:text-gray-700">|</span>
+            <span className="text-gray-300 dark:text-gray-600">|</span>
             <span className="flex items-center gap-1.5">
-              <span className="text-gray-300 dark:text-gray-600">Book:</span>
+              <span className="text-gray-300 dark:text-gray-500">Book:</span>
               <span className="tabular-nums">{bookStats.totalWords.toLocaleString()} words</span>
             </span>
             {sessionStats.wordsThisSession > 0 && (
               <>
-                <span className="text-gray-300 dark:text-gray-700">|</span>
+                <span className="text-gray-300 dark:text-gray-600">|</span>
                 <span className="text-green-500/70 dark:text-green-500/50 tabular-nums">
                   +{sessionStats.wordsThisSession.toLocaleString()} this session
                 </span>
@@ -196,7 +196,7 @@ export default function EditorCanvas({
           </div>
           {/* Quiet "words today" nudge. No streak, no flame, no grind. */}
           {todayWords > 0 && (
-            <span className="text-xs text-gray-500 dark:text-[#888] tabular-nums">
+            <span className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">
               {todayWords.toLocaleString()} words today
             </span>
           )}

--- a/app/make-ebook/components/HistoryPanel.tsx
+++ b/app/make-ebook/components/HistoryPanel.tsx
@@ -91,11 +91,11 @@ export default function HistoryPanel({
   return (
     <div className="fixed inset-0 z-[130] bg-black/20 flex items-center justify-center p-4" onClick={onClose}>
       <div
-        className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl w-full max-w-md max-h-[80vh] flex flex-col overflow-hidden"
+        className="bg-white dark:bg-[#2f2f2f] rounded-xl shadow-2xl w-full max-w-md max-h-[80vh] flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-[#333]">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-[#3a3a3a]">
           <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">History</h2>
           <button
             onClick={onClose}

--- a/app/make-ebook/components/ResizableRightPanel.tsx
+++ b/app/make-ebook/components/ResizableRightPanel.tsx
@@ -74,7 +74,7 @@ export default function ResizableRightPanel({ children, className = '' }: Resiza
     <div
       ref={panelRef}
       style={{ width: isExpanded ? width : 0 }}
-      className={`hidden lg:flex flex-col flex-shrink-0 h-screen overflow-hidden border-l border-gray-200 dark:border-[#2f2f2f] relative transition-[width] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] overflow-x-hidden ${className}`}
+      className={`hidden lg:flex flex-col flex-shrink-0 h-screen overflow-hidden border-l-2 border-gray-300 dark:border-[#404040] relative transition-[width] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] overflow-x-hidden shadow-xl dark:shadow-black/20 ${className}`}
     >
       {/* Resize handle — left edge */}
       <div

--- a/app/make-ebook/components/RichTextEditor.tsx
+++ b/app/make-ebook/components/RichTextEditor.tsx
@@ -886,7 +886,7 @@ export default function RichTextEditor({
       )}
 
       {/* Full Toolbar - Hidden on mobile when keyboard is open */}
-      {!hideToolbar && <div className={`bg-white dark:bg-[#262626] border-b border-gray-200 dark:border-[#2f2f2f] transition-all duration-200 overflow-visible ${
+      {!hideToolbar && <div className={`transition-all duration-200 overflow-visible ${
         isMobileKeyboardOpen ? 'lg:block hidden' : ''
       }`}>
         {/* Sleek horizontal toolbar */}
@@ -901,7 +901,7 @@ export default function RichTextEditor({
               aria-label="Undo"
               type="button"
               disabled={disabled}
-              className="w-9 h-9 rounded-lg flex items-center justify-center bg-gray-100 dark:bg-[#1e1e1e] text-gray-700 dark:text-[#d4d4d4] active:scale-[0.96] transition-transform touch-manipulation"
+              className="w-9 h-9 rounded-lg flex items-center justify-center hover:bg-gray-100 dark:hover:bg-[#2d2d2d] text-gray-700 dark:text-[#d4d4d4] active:scale-[0.96] transition-all touch-manipulation"
             >
               <img src="/undo-icon.svg" alt="" aria-hidden="true" className="w-4 h-4 dark:invert" style={{ borderRadius: 0, boxShadow: 'none' }} />
             </button>
@@ -912,7 +912,7 @@ export default function RichTextEditor({
               aria-label="Redo"
               type="button"
               disabled={disabled}
-              className="w-9 h-9 rounded-lg flex items-center justify-center bg-gray-100 dark:bg-[#1e1e1e] text-gray-700 dark:text-[#d4d4d4] active:scale-[0.96] transition-transform touch-manipulation"
+              className="w-9 h-9 rounded-lg flex items-center justify-center hover:bg-gray-100 dark:hover:bg-[#2d2d2d] text-gray-700 dark:text-[#d4d4d4] active:scale-[0.96] transition-all touch-manipulation"
             >
               <img src="/redo-icon.svg" alt="" aria-hidden="true" className="w-4 h-4 dark:invert" style={{ borderRadius: 0, boxShadow: 'none' }} />
             </button>
@@ -951,7 +951,7 @@ export default function RichTextEditor({
               connected control (not separate pills) so the highlighted item
               reads as "the current style" rather than a toggle that's stuck on.
               This is why "P" looking active no longer implies a hidden state. */}
-          <div role="group" aria-label="Paragraph style" className="flex items-center gap-0.5 flex-shrink-0 rounded-lg bg-gray-100 dark:bg-[#1e1e1e] p-0.5">
+          <div role="group" aria-label="Paragraph style" className="flex items-center gap-0.5 flex-shrink-0 rounded-lg p-0.5">
             {HEADINGS.map(h => {
               const active = !!formats[`heading${h.level}`];
               return (
@@ -966,7 +966,7 @@ export default function RichTextEditor({
                   disabled={disabled}
                   className={`w-8 h-8 rounded-md flex items-center justify-center text-xs font-bold transition-colors touch-manipulation ${
                     active
-                      ? 'bg-white dark:bg-[#3a3a3a] text-gray-900 dark:text-white shadow-sm'
+                      ? 'bg-gray-200 dark:bg-[#3a3a3a] text-gray-900 dark:text-white'
                       : 'text-gray-500 dark:text-[#a3a3a3] hover:text-gray-700 dark:hover:text-[#d4d4d4]'
                   }`}
                 >
@@ -1069,7 +1069,7 @@ export default function RichTextEditor({
               aria-label="Outdent"
               type="button"
               disabled={disabled}
-              className="w-9 h-9 rounded-lg flex items-center justify-center bg-gray-100 dark:bg-[#1e1e1e] text-gray-600 dark:text-[#d4d4d4] active:scale-[0.96] transition-transform touch-manipulation"
+              className="w-9 h-9 rounded-lg flex items-center justify-center hover:bg-gray-100 dark:hover:bg-[#2d2d2d] text-gray-600 dark:text-[#d4d4d4] active:scale-[0.96] transition-all touch-manipulation"
             >
               <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
                 <path d="M3 6h18M9 12h12M9 18h12" /><path d="M7 9l-4 3 4 3" />
@@ -1105,7 +1105,7 @@ export default function RichTextEditor({
               aria-label="Indent"
               type="button"
               disabled={disabled}
-              className="w-9 h-9 rounded-lg flex items-center justify-center bg-gray-100 dark:bg-[#1e1e1e] text-gray-600 dark:text-[#d4d4d4] active:scale-[0.96] transition-transform touch-manipulation"
+              className="w-9 h-9 rounded-lg flex items-center justify-center hover:bg-gray-100 dark:hover:bg-[#2d2d2d] text-gray-600 dark:text-[#d4d4d4] active:scale-[0.96] transition-all touch-manipulation"
             >
               <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
                 <path d="M3 6h18M9 12h12M9 18h12" /><path d="M3 9l4 3-4 3" />
@@ -1125,7 +1125,7 @@ export default function RichTextEditor({
               aria-label="Insert endnote"
               type="button"
               disabled={disabled || !onCreateEndnote}
-              className="w-9 h-9 rounded-lg bg-gray-100 dark:bg-[#1e1e1e] flex items-center justify-center active:scale-[0.96] transition-transform touch-manipulation disabled:opacity-50"
+              className="w-9 h-9 rounded-lg hover:bg-gray-100 dark:hover:bg-[#2d2d2d] flex items-center justify-center active:scale-[0.96] transition-all touch-manipulation disabled:opacity-50"
             >
               <Image src="/endnote-icon.svg" alt="" aria-hidden="true" width={14} height={14} className="w-3.5 h-3.5 dark:invert" style={{ borderRadius: 0, boxShadow: 'none' }} />
             </button>
@@ -1164,7 +1164,7 @@ export default function RichTextEditor({
             aria-label="Insert image"
             type="button"
             disabled={disabled}
-            className="w-9 h-9 rounded-lg bg-gray-100 dark:bg-[#1e1e1e] flex items-center justify-center active:scale-[0.96] transition-transform touch-manipulation flex-shrink-0"
+            className="w-9 h-9 rounded-lg hover:bg-gray-100 dark:hover:bg-[#2d2d2d] flex items-center justify-center active:scale-[0.96] transition-all touch-manipulation flex-shrink-0"
           >
             <img src="/image-icon.svg" alt="" aria-hidden="true" className="w-3.5 h-3.5 dark:invert" style={{ borderRadius: 0, boxShadow: 'none' }} />
           </button>
@@ -1182,7 +1182,7 @@ export default function RichTextEditor({
             aria-label="Remove all formatting"
             type="button"
             disabled={disabled}
-            className="w-9 h-9 rounded-lg bg-gray-100 dark:bg-[#1e1e1e] flex items-center justify-center active:scale-[0.96] transition-transform touch-manipulation flex-shrink-0"
+            className="w-9 h-9 rounded-lg hover:bg-gray-100 dark:hover:bg-[#2d2d2d] flex items-center justify-center active:scale-[0.96] transition-all touch-manipulation flex-shrink-0"
           >
             <img src="/clear-erase-icon.svg" alt="" aria-hidden="true" className="w-3.5 h-3.5 dark:invert" style={{ borderRadius: 0, boxShadow: 'none' }} />
           </button>

--- a/app/make-ebook/components/bookmind/InspectorPanel.tsx
+++ b/app/make-ebook/components/bookmind/InspectorPanel.tsx
@@ -9,6 +9,7 @@ import ChatTab from "./tabs/ChatTab";
 import ProfileTab from "./tabs/ProfileTab";
 import InsightsTab from "./tabs/InsightsTab";
 import IssuesTab from "./tabs/IssuesTab";
+import MemoryTab from "./tabs/MemoryTab";
 import PreflightTab from "./tabs/PreflightTab";
 import type { Chapter, BookRecord } from "../../types";
 import { loadBookById } from "../../utils/bookLibrary";
@@ -32,13 +33,14 @@ interface InspectorPanelProps {
   onUpgrade?: () => void;
 }
 
-type TabKey = "chat" | "profile" | "insights" | "issues" | "preflight";
+type TabKey = "chat" | "profile" | "insights" | "issues" | "memory" | "preflight";
 
 const TABS: Array<{ key: TabKey; label: string }> = [
   { key: "chat",      label: "Chat" },
   { key: "profile",   label: "Profile" },
   { key: "insights",  label: "Insights" },
   { key: "issues",    label: "Issues" },
+  { key: "memory",    label: "Memory" },
   { key: "preflight", label: "Preflight" },
 ];
 
@@ -46,14 +48,19 @@ export default function InspectorPanel(props: InspectorPanelProps) {
   const isPro = props.isPro ?? true;
   const visibleTabs = isPro ? TABS : TABS.filter(t => t.key === "chat");
   const [active, setActive] = useState<TabKey>("chat");
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
   const { onClose } = props;
+
+  const handleDismissOrRefresh = () => {
+    setRefreshTrigger(prev => prev + 1);
+  };
 
   // Load the full record for the analytical tabs. Reads are cheap so
   // re-running on tab switch is fine.
   const book: BookRecord | undefined = useMemo(() => {
     if (!props.bookId || !props.userId) return undefined;
     return loadBookById(props.userId, props.bookId);
-  }, [props.bookId, props.userId, active]); // re-read when switching tabs
+  }, [props.bookId, props.userId, active, refreshTrigger]); // re-read when switching tabs or after dismiss
 
   const chapterIndex = useMemo(
     () => props.chapters.map(c => ({ id: c.id, title: c.title })),
@@ -148,6 +155,14 @@ export default function InspectorPanel(props: InspectorPanelProps) {
             chapters={chapterIndex}
             onNavigateToChapter={props.onNavigateToChapter}
             onRefresh={props.onRefreshAnalytical}
+            onDismiss={handleDismissOrRefresh}
+          />
+        </TabsContent>
+        <TabsContent value="memory" className="flex-1 min-h-0 mt-0 outline-none">
+          <MemoryTab
+            book={book}
+            userId={props.userId}
+            onUpdate={handleDismissOrRefresh}
           />
         </TabsContent>
         <TabsContent value="preflight" className="flex-1 min-h-0 mt-0 outline-none">

--- a/app/make-ebook/components/bookmind/tabs/ChatTab.tsx
+++ b/app/make-ebook/components/bookmind/tabs/ChatTab.tsx
@@ -281,7 +281,7 @@ export default function ChatTab({
                 </svg>
               </button>
             </PopoverTrigger>
-            <PopoverContent align="end" sideOffset={4} className="w-64 p-0 max-h-96 overflow-y-auto bg-white dark:bg-[#252525] border border-gray-200 dark:border-[#2f2f2f] rounded-card shadow-lg">
+            <PopoverContent align="end" sideOffset={4} className="w-64 p-0 max-h-96 overflow-y-auto bg-white dark:bg-[#2f2f2f] border border-gray-200 dark:border-[#3a3a3a] rounded-card shadow-lg dark:shadow-black/40">
               <div className="px-2.5 py-2 border-b border-gray-100 dark:border-[#2f2f2f] flex items-center justify-between sticky top-0 bg-white dark:bg-[#252525]">
                 <span className="text-10 font-medium text-gray-500 dark:text-[#a3a3a3] uppercase tracking-wide">Recent</span>
                 <span className="text-10 text-gray-400 dark:text-[#737373]">{sortedSessions.length}</span>
@@ -315,7 +315,7 @@ export default function ChatTab({
   );
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-[#2c2c2c] text-gray-900 dark:text-white overflow-hidden">
+    <div className="flex flex-col h-full bg-white dark:bg-[#303030] text-gray-900 dark:text-white overflow-hidden">
       {Header}
 
       <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3 min-h-0">
@@ -326,24 +326,7 @@ export default function ChatTab({
                 <BookIcon className="w-6 h-6 text-gray-300 dark:text-[#737373] mx-auto mb-2.5" />
                 <p className="text-12 text-gray-500 dark:text-[#a3a3a3]">Open a book to get started.</p>
               </div>
-            ) : (
-              <>
-                <div className="text-center pt-6 pb-2">
-                  <h3 className="text-13 font-medium text-gray-900 dark:text-white mb-1" style={{ fontFamily: 'var(--font-playfair)', fontWeight: 400, letterSpacing: '-0.01em' }}>Ask anything about your book.</h3>
-                  <p className="text-11 text-gray-500 dark:text-[#a3a3a3] max-w-xs mx-auto">Try a quick action or type your question.</p>
-                </div>
-                <div className="grid grid-cols-2 gap-2">
-                  {QUICK_ACTIONS.slice(0, isPro ? 4 : 2).map(({ action, label, description }, idx) => (
-                    <button key={action} onClick={() => handleQuickAction(action)} disabled={isLoading} className="group flex items-start gap-2 p-2.5 rounded-card border border-gray-200 dark:border-[#2f2f2f] hover:border-gray-300 dark:hover:border-[#3a3a3a] hover:bg-gray-50 dark:hover:bg-[#2d2d2d] transition-all duration-150 text-left disabled:opacity-50 active:scale-[0.96]" style={{ animation: `fade-up 350ms cubic-bezier(0.23,1,0.32,1) ${idx * 60}ms both` }}>
-                      <div className="flex-1 min-w-0">
-                        <span className="text-125 font-semibold text-gray-900 dark:text-white block leading-tight">{label}</span>
-                        <span className="text-10 text-gray-500 dark:text-[#737373] mt-0.5 block">{description}</span>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </>
-            )}
+            ) : null}
           </div>
         ) : (
           <>
@@ -374,6 +357,18 @@ export default function ChatTab({
         </div>
       ) : (
         <div className="flex-shrink-0 px-3 pb-3 pt-2 space-y-2">
+          {messages.length === 0 && chapters.length > 0 && (
+            <div className="grid grid-cols-2 gap-2 mb-2">
+              {QUICK_ACTIONS.slice(0, isPro ? 4 : 2).map(({ action, label, description }, idx) => (
+                <button key={action} onClick={() => handleQuickAction(action)} disabled={isLoading} className="group flex items-start gap-2 p-2.5 rounded-card border border-gray-200 dark:border-[#2f2f2f] hover:border-gray-300 dark:hover:border-[#3a3a3a] hover:bg-gray-50 dark:hover:bg-[#363636] hover:shadow-md dark:hover:shadow-black/20 transition-all duration-150 text-left disabled:opacity-50 active:scale-[0.96]" style={{ animation: `fade-up 350ms cubic-bezier(0.23,1,0.32,1) ${idx * 60}ms both` }}>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-125 font-semibold text-gray-900 dark:text-white block leading-tight">{label}</span>
+                    <span className="text-10 text-gray-500 dark:text-[#737373] mt-0.5 block">{description}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
           {activeSelectedText && (
             <div className="rounded-control bg-gray-50 dark:bg-[#232323] border border-gray-200 dark:border-[#2f2f2f] px-2.5 py-2">
               <div className="flex items-center justify-between mb-1">
@@ -384,7 +379,7 @@ export default function ChatTab({
             </div>
           )}
           {showSlashMenu && filteredSlash.length > 0 && (
-            <div className="rounded-card bg-white dark:bg-[#252525] border border-gray-200 dark:border-[#2f2f2f] shadow-md overflow-hidden" style={{ animation: 'pop-in 200ms cubic-bezier(0.23,1,0.32,1) both' }}>
+            <div className="rounded-card bg-white dark:bg-[#2f2f2f] border border-gray-200 dark:border-[#3a3a3a] shadow-md dark:shadow-black/40 overflow-hidden" style={{ animation: 'pop-in 200ms cubic-bezier(0.23,1,0.32,1) both' }}>
               <div className="px-2.5 py-1.5 border-b border-gray-100 dark:border-[#3a3a3a] bg-white dark:bg-[#252525]">
                 <span className="text-10 text-gray-400 dark:text-[#737373] font-medium uppercase tracking-wide">Commands</span>
               </div>
@@ -396,14 +391,14 @@ export default function ChatTab({
               ))}
             </div>
           )}
-          <div className="flex items-end gap-1.5 rounded-card bg-white dark:bg-[#252525] border border-gray-200 dark:border-[#2f2f2f] px-2.5 py-2">
-            <textarea ref={inputRef} value={input} onChange={e => { setInput(e.target.value); e.target.style.height = "auto"; e.target.style.height = Math.min(e.target.scrollHeight, 100) + "px"; }} onKeyDown={handleKeyDown} placeholder={chapters.length > 0 ? "Ask anything…" : "Open a book first…"} disabled={chapters.length === 0} rows={1} className="chat-composer flex-1 bg-transparent text-12 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-[#888] resize-none max-h-[100px] leading-relaxed disabled:opacity-50 py-0.5" style={{ border: 'none', outline: 'none', boxShadow: 'none', appearance: 'none', WebkitAppearance: 'none', padding: '0', fontFamily: 'inherit', fontSize: '0.875rem' }} />
+          <div className="flex items-end gap-1.5 rounded-full bg-white dark:bg-[#1a1a1a] border border-gray-200 dark:border-[#2f2f2f] px-3 py-2">
+            <textarea ref={inputRef} value={input} onChange={e => { setInput(e.target.value); e.target.style.height = "auto"; e.target.style.height = Math.min(e.target.scrollHeight, 100) + "px"; }} onKeyDown={handleKeyDown} placeholder={chapters.length > 0 ? "Ask anything about your book…" : "Open a book first…"} disabled={chapters.length === 0} rows={1} className="chat-composer flex-1 bg-transparent text-12 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-[#888] resize-none max-h-[100px] leading-relaxed disabled:opacity-50 py-0.5" style={{ border: 'none', outline: 'none', boxShadow: 'none', appearance: 'none', WebkitAppearance: 'none', padding: '0', fontFamily: 'inherit', fontSize: '0.875rem' }} />
             {isLoading ? (
-              <button onClick={stop} className="flex-shrink-0 size-6 rounded-control bg-red-600 text-white flex items-center justify-center hover:bg-red-700 transition-colors" title="Stop">
+              <button onClick={stop} className="flex-shrink-0 size-6 rounded-full bg-red-600 text-white flex items-center justify-center hover:bg-red-700 transition-colors" title="Stop">
                 <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="1" /></svg>
               </button>
             ) : (
-              <button onClick={handleSend} disabled={!input.trim() || chapters.length === 0} className="flex-shrink-0 size-6 rounded-control bg-gray-900 dark:bg-white text-white dark:text-black flex items-center justify-center hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+              <button onClick={handleSend} disabled={!input.trim() || chapters.length === 0} className="flex-shrink-0 size-6 rounded-full bg-gray-900 dark:bg-white text-white dark:text-black flex items-center justify-center hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
                 <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}><path strokeLinecap="round" strokeLinejoin="round" d="M5 12l7-7 7 7" /></svg>
               </button>
             )}
@@ -460,7 +455,7 @@ function MessageBubble({
 
   return (
     <div className={`group flex flex-col ${isUser ? "items-end" : "items-start"}`} style={{ animation: 'fade-up 300ms cubic-bezier(0.23,1,0.32,1) both' }}>
-      <div className={`max-w-[85%] rounded-card px-3 py-2.5 text-125 leading-relaxed ${isUser ? "bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-tr-sm" : "bg-gray-100 dark:bg-[#262626] text-gray-800 dark:text-[#f5f5f5] rounded-tl-sm"}`}>
+      <div className={`max-w-[85%] rounded-card px-3 py-2.5 text-125 leading-relaxed ${isUser ? "bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-tr-sm" : "bg-gray-100 dark:bg-[#303030] text-gray-800 dark:text-[#f5f5f5] rounded-tl-sm"}`}>
         {!message.content ? (
           <ShimmerLoader />
         ) : structured ? (

--- a/app/make-ebook/components/bookmind/tabs/IssuesTab.tsx
+++ b/app/make-ebook/components/bookmind/tabs/IssuesTab.tsx
@@ -22,6 +22,7 @@ interface IssuesTabProps {
   chapters: Array<{ id: string; title: string }>;
   onNavigateToChapter?: (chapterIndex: number) => void;
   onRefresh?: (kind: AnalyticalKind) => void;
+  onDismiss?: () => void;
 }
 
 export default function IssuesTab({
@@ -30,6 +31,7 @@ export default function IssuesTab({
   chapters,
   onNavigateToChapter,
   onRefresh,
+  onDismiss,
 }: IssuesTabProps) {
   if (!book) {
     return <EmptyState message="Open a book to check for issues." />;
@@ -48,6 +50,7 @@ export default function IssuesTab({
   const handleDismiss = (card: AnalyticalCard, idx: number) => {
     if (!userId || !book) return;
     dismissIssue(userId, book.id, issueId(card, idx));
+    onDismiss?.();
   };
 
   return (

--- a/app/make-ebook/components/bookmind/tabs/MemoryTab.tsx
+++ b/app/make-ebook/components/bookmind/tabs/MemoryTab.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { BookRecord } from "../../../types";
+import { getMemory, removeRule, removeCharacter, addRule, addDecision, setCharacter } from "../../../utils/bookmindMemory";
+import { BookMindIcon as BookIcon } from "../../BookMindShared";
+
+interface MemoryTabProps {
+  book: BookRecord | undefined;
+  userId?: string;
+  onUpdate?: () => void;
+}
+
+type MemoryEntry = {
+  id: string;
+  type: "rule" | "character" | "analytical" | "decision";
+  title: string;
+  content: string;
+  timestamp?: number;
+  deleteKey?: string | number; // for deleting: rule string or character name
+};
+
+export default function MemoryTab({
+  book,
+  userId,
+  onUpdate,
+}: MemoryTabProps) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [newRule, setNewRule] = useState("");
+  const [newCharName, setNewCharName] = useState("");
+  const [newCharDesc, setNewCharDesc] = useState("");
+  const [newDecision, setNewDecision] = useState("");
+
+  if (!book) {
+    return <EmptyState message="Open a book to view memory." />;
+  }
+
+  const memory = getMemory(book);
+
+  // Build memory entries list
+  const entries: MemoryEntry[] = [];
+
+  // Add rules
+  (memory.rules ?? []).forEach((rule, idx) => {
+    entries.push({
+      id: `rule-${idx}`,
+      type: "rule",
+      title: "Rule",
+      content: rule,
+      timestamp: Date.now(),
+      deleteKey: rule, // store the actual rule string for deletion
+    });
+  });
+
+  // Add characters
+  Object.entries(memory.characters ?? {}).forEach(([name, desc]) => {
+    entries.push({
+      id: `character-${name}`,
+      type: "character",
+      title: name,
+      content: desc,
+      timestamp: Date.now(),
+      deleteKey: name, // store the character name for deletion
+    });
+  });
+
+  // Add analytical entries if they exist
+  if (memory.analytical) {
+    entries.push({
+      id: "analytical",
+      type: "analytical",
+      title: "Book Analysis",
+      content: `Themes, characters, pacing, and word frequency analysis cached`,
+      timestamp: Date.now(),
+    });
+  }
+
+  if (memory.decisions) {
+    entries.push({
+      id: "decisions",
+      type: "decision",
+      title: "Editorial Decisions",
+      content: `${Object.keys(memory.decisions).length} decisions recorded`,
+      timestamp: Date.now(),
+    });
+  }
+
+  const handleAddRule = () => {
+    if (!userId || !book || !newRule.trim()) return;
+    addRule(userId, book.id, newRule.trim());
+    setNewRule("");
+    onUpdate?.();
+  };
+
+  const handleAddCharacter = () => {
+    if (!userId || !book || !newCharName.trim() || !newCharDesc.trim()) return;
+    setCharacter(userId, book.id, newCharName.trim(), newCharDesc.trim());
+    setNewCharName("");
+    setNewCharDesc("");
+    onUpdate?.();
+  };
+
+  const handleAddDecision = () => {
+    if (!userId || !book || !newDecision.trim()) return;
+    addDecision(userId, book.id, newDecision.trim());
+    setNewDecision("");
+    onUpdate?.();
+  };
+
+  const handleDeleteRule = (rule: string) => {
+    if (!userId || !book) return;
+    removeRule(userId, book.id, rule);
+    setDeletingId(null);
+    onUpdate?.();
+  };
+
+  const handleDeleteCharacter = (name: string) => {
+    if (!userId || !book) return;
+    removeCharacter(userId, book.id, name);
+    setDeletingId(null);
+    onUpdate?.();
+  };
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex flex-col h-full bg-white dark:bg-[#2c2c2c] text-gray-900 dark:text-white">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-[#2f2f2f] flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <svg className="w-5 h-5 text-gray-500 dark:text-[#a3a3a3]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            <span className="text-sm font-medium">Memory</span>
+          </div>
+        </div>
+        <div className="flex-1 flex items-center justify-center p-8">
+          <div className="text-center space-y-3 max-w-[260px]">
+            <BookIcon className="w-8 h-8 text-gray-300 dark:text-[#737373] mx-auto" />
+            <p className="text-sm text-gray-500 dark:text-[#a3a3a3]">No memory yet. Use the chat to teach Book Mind about your manuscript.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-white dark:bg-[#2c2c2c] text-gray-900 dark:text-white">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-[#2f2f2f] flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-gray-500 dark:text-[#a3a3a3]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <span className="text-sm font-medium">Memory</span>
+          <span className="text-xs text-gray-400 dark:text-[#737373]">
+            {entries.length}
+          </span>
+        </div>
+      </div>
+
+      {/* Add to Memory section */}
+      <div className="flex-shrink-0 border-b border-gray-200 dark:border-[#2f2f2f] px-4 py-3 space-y-2">
+        <div className="flex gap-1.5">
+          <input
+            type="text"
+            value={newRule}
+            onChange={(e) => setNewRule(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAddRule()}
+            placeholder="Add a rule..."
+            className="flex-1 text-11 px-2.5 py-1.5 rounded bg-gray-50 dark:bg-[#262626] border border-gray-200 dark:border-[#2f2f2f] text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-[#888] outline-none focus:border-gray-300 dark:focus:border-[#3a3a3a]"
+          />
+          <button
+            onClick={handleAddRule}
+            disabled={!newRule.trim()}
+            className="px-2.5 py-1.5 text-11 font-medium rounded bg-blue-500 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors active:scale-[0.96]"
+          >
+            Add
+          </button>
+        </div>
+        <div className="flex gap-1.5">
+          <input
+            type="text"
+            value={newCharName}
+            onChange={(e) => setNewCharName(e.target.value)}
+            placeholder="Character name..."
+            className="flex-1 text-11 px-2.5 py-1.5 rounded bg-gray-50 dark:bg-[#262626] border border-gray-200 dark:border-[#2f2f2f] text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-[#888] outline-none focus:border-gray-300 dark:focus:border-[#3a3a3a]"
+          />
+          <input
+            type="text"
+            value={newCharDesc}
+            onChange={(e) => setNewCharDesc(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAddCharacter()}
+            placeholder="Description..."
+            className="flex-1 text-11 px-2.5 py-1.5 rounded bg-gray-50 dark:bg-[#262626] border border-gray-200 dark:border-[#2f2f2f] text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-[#888] outline-none focus:border-gray-300 dark:focus:border-[#3a3a3a]"
+          />
+          <button
+            onClick={handleAddCharacter}
+            disabled={!newCharName.trim() || !newCharDesc.trim()}
+            className="px-2.5 py-1.5 text-11 font-medium rounded bg-purple-500 hover:bg-purple-600 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors active:scale-[0.96]"
+          >
+            Add
+          </button>
+        </div>
+        <div className="flex gap-1.5">
+          <input
+            type="text"
+            value={newDecision}
+            onChange={(e) => setNewDecision(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAddDecision()}
+            placeholder="Add a decision..."
+            className="flex-1 text-11 px-2.5 py-1.5 rounded bg-gray-50 dark:bg-[#262626] border border-gray-200 dark:border-[#2f2f2f] text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-[#888] outline-none focus:border-gray-300 dark:focus:border-[#3a3a3a]"
+          />
+          <button
+            onClick={handleAddDecision}
+            disabled={!newDecision.trim()}
+            className="px-2.5 py-1.5 text-11 font-medium rounded bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors active:scale-[0.96]"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {/* Memory entries */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {entries.map((entry, idx) => (
+          <MemoryCard
+            key={entry.id}
+            entry={entry}
+            onDelete={() => {
+              if (entry.type === "rule" && typeof entry.deleteKey === "string") {
+                handleDeleteRule(entry.deleteKey);
+              } else if (entry.type === "character" && typeof entry.deleteKey === "string") {
+                handleDeleteCharacter(entry.deleteKey);
+              }
+            }}
+            isDeleting={deletingId === entry.id}
+            onDeleteStart={() => setDeletingId(entry.id)}
+            onDeleteCancel={() => setDeletingId(null)}
+          />
+        ))}
+        <div className="h-4" />
+      </div>
+    </div>
+  );
+}
+
+function MemoryCard({
+  entry,
+  onDelete,
+  isDeleting,
+  onDeleteStart,
+  onDeleteCancel,
+}: {
+  entry: MemoryEntry;
+  onDelete: () => void;
+  isDeleting: boolean;
+  onDeleteStart: () => void;
+  onDeleteCancel: () => void;
+}) {
+  const typeColors = {
+    rule: {
+      bg: "bg-blue-500/10 dark:bg-blue-500/15",
+      text: "text-blue-600 dark:text-blue-400",
+      label: "Rule",
+    },
+    character: {
+      bg: "bg-purple-500/10 dark:bg-purple-500/15",
+      text: "text-purple-600 dark:text-purple-400",
+      label: "Character",
+    },
+    analytical: {
+      bg: "bg-amber-500/10 dark:bg-amber-500/15",
+      text: "text-amber-600 dark:text-amber-400",
+      label: "Analysis",
+    },
+    decision: {
+      bg: "bg-emerald-500/10 dark:bg-emerald-500/15",
+      text: "text-emerald-600 dark:text-emerald-400",
+      label: "Decision",
+    },
+  };
+
+  const colors = typeColors[entry.type];
+
+  return (
+    <div
+      className="group p-3 rounded-lg bg-gray-50 dark:bg-[#262626] border border-gray-100 dark:border-[#2f2f2f] hover:border-gray-200 dark:hover:border-[#3a3a3a] transition-all"
+      style={{ animation: "fade-up 300ms cubic-bezier(0.23,1,0.32,1) both" }}
+    >
+      <div className="flex items-start justify-between gap-2 mb-1.5">
+        <span className={`text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
+          {colors.label}
+        </span>
+        {!isDeleting ? (
+          <button
+            onClick={onDeleteStart}
+            className="opacity-0 group-hover:opacity-100 text-2xs text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors px-1"
+            title="Delete"
+          >
+            Delete
+          </button>
+        ) : (
+          <div className="opacity-100 flex items-center gap-1">
+            <button
+              onClick={onDelete}
+              className="text-2xs text-red-600 dark:text-red-400 font-medium hover:text-red-700 dark:hover:text-red-300 transition-colors"
+            >
+              Yes
+            </button>
+            <span className="text-gray-400 dark:text-[#737373]">/</span>
+            <button
+              onClick={onDeleteCancel}
+              className="text-2xs text-gray-600 dark:text-[#a3a3a3] hover:text-gray-900 dark:hover:text-white transition-colors"
+            >
+              No
+            </button>
+          </div>
+        )}
+      </div>
+      <h3 className="text-12 font-medium text-gray-900 dark:text-white mb-1">
+        {entry.title}
+      </h3>
+      <p className="text-11 text-gray-600 dark:text-[#a3a3a3] leading-relaxed">
+        {entry.content}
+      </p>
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col h-full bg-white dark:bg-[#2c2c2c] text-gray-900 dark:text-white">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-[#2f2f2f] flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-gray-500 dark:text-[#a3a3a3]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <span className="text-sm font-medium">Memory</span>
+        </div>
+      </div>
+      <div className="flex-1 flex items-center justify-center p-8">
+        <div className="text-center space-y-3 max-w-[260px]">
+          <BookIcon className="w-8 h-8 text-gray-300 dark:text-[#737373] mx-auto" />
+          <p className="text-sm text-gray-500 dark:text-[#a3a3a3]">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add a new Memory tab to Book Mind.
Applied UI polish across the editor and Book Mind surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Memory tab for viewing, adding, editing, and deleting book rules, characters, analysis, and editorial decisions.
  - Memory and dismissed issue updates now refresh Book Mind data automatically.
  - Improved chat composer layout, quick actions, controls, and empty-state presentation.

- **Style**
  - Refined dark-mode colors across popovers, history, editor statistics, chat, and panels.
  - Improved toolbar hover states, transitions, borders, and panel shadows for a more polished interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->