### PR TITLE
Remove disabled prop from MessageActions call

### DIFF
--- a/app/make-ebook/components/bookmind/tabs/ChatTab.tsx
+++ b/app/make-ebook/components/bookmind/tabs/ChatTab.tsx
@@ -501,7 +501,7 @@ function MessageBubble({
 
       {isAssistant && message.content && (
         <div className="mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-          <MessageActions content={message.content} onRegenerate={onRegenerate} onContinue={onContinue} onOpenReadingView={isPro ? onOpenReadingView : undefined} onRemember={isPro ? onRemember : undefined} disabled={disabled} isPro={isPro} />
+          <MessageActions content={message.content} onRegenerate={onRegenerate} onContinue={onContinue} onOpenReadingView={isPro ? onOpenReadingView : undefined} onRemember={isPro ? onRemember : undefined} isPro={isPro} />
         </div>
       )}
     </div>


### PR DESCRIPTION
Drop the unused `disabled` prop when rendering MessageActions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored message actions so they are no longer unnecessarily disabled in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->